### PR TITLE
Create overlay for movie panels

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -59,6 +59,7 @@ html {
 .movie-panel-overlay h3 {
     margin: 15px 15px;
     color: #fff;
+    font-size: 28px;
 }
 
 /* dirty, but w/e. selects the button container divs */

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -29,7 +29,43 @@
     width: 5%;
 }
 
+.carousel-inner .item .row {
+    display: flex;
+    align-items: center;
+}
+
 html {
     padding-left: 5px;
     padding-right: 5px;
+}
+
+.movie-panel {
+    position: relative;
+}
+
+.movie-panel-overlay {
+    position: absolute;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.7);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 0;
+    margin: 0 15px;
+}
+
+.movie-panel-overlay h3 {
+    margin: 15px 15px;
+    color: #fff;
+}
+
+/* dirty, but w/e. selects the button container divs */
+.movie-panel-overlay > div {
+    position: absolute;
+    bottom: 15px;
+}
+
+.movie-panel-overlay .save-button {
+    position: absolute;
+    bottom: 0;
 }

--- a/static/js/movies.js
+++ b/static/js/movies.js
@@ -2,7 +2,7 @@
 
     // TODO: We're going to need data-* attributes to prevent expanding/collapsing/etc all of
     // the buttons at once
-    $('div').on('click', '#save-button', function (e) {
+    $('div').on('click', '.save-button', function (e) {
         var id = $(this).attr('data-id');
         $('#save-button-div-' + id).collapse('hide');
         $('#watched-buttons-' + id).collapse('show');
@@ -33,6 +33,15 @@
                 }
             });
         }
+    });
+
+
+    // Display overlay when the user hovers over a movie panel
+    $('.movie-panel').on('mouseenter', function () {
+        $(this).find('.movie-panel-overlay').finish();
+        $(this).find('.movie-panel-overlay').fadeIn(150);
+    }).on('mouseleave', function () {
+        $(this).find('.movie-panel-overlay').fadeOut(150);
     });
 
 })(window.jQuery);

--- a/views/partials/movie-panel.ejs
+++ b/views/partials/movie-panel.ejs
@@ -1,27 +1,27 @@
 <div class="col-md-2">
-    <h3><%= movie.title %></h3>
-    <div class="row">
+    <div class="movie-panel row">
         <img class="img-responsive col-md-12" src="<%= movie.image %>" alt="<%= movie.title %> Cover">
-    </div>
-    <div class="row">
-    <% if (user) { %>
-        <div class="col-md-12 collapse in" id="save-button-div-<%= movie._id %>" data-toggle="collapse">
-            <button class="btn btn-primary" id="save-button" data-id="<%= movie._id %>">Save</button>
+        <div class="movie-panel-overlay">
+            <h3><%= movie.title %></h3>
+                <% if (user) { %>
+                    <div class="col-md-12 collapse in" id="save-button-div-<%= movie._id %>" data-toggle="collapse">
+                        <button class="btn btn-primary save-button" data-id="<%= movie._id %>">Save</button>
+                    </div>
+                    <div class="col-md-12 collapse" id="watched-buttons-<%= movie._id %>" data-toggle="collapse">
+                        <button
+                            class="btn btn-default watched-btn"
+                            data-id="<%= movie._id %>"
+                        >Have not watched</button>
+                        <button
+                            class="btn btn-primary watched-btn"
+                            data-id="<%= movie._id %>"
+                        >Have watched</button>
+                        <button
+                            class="btn btn-warning watched-btn"
+                            data-id="<%= movie._id %>"
+                        >Will not watch</button>
+                    </div>
+                <% } %>
         </div>
-        <div class="col-md-12 collapse" id="watched-buttons-<%= movie._id %>" data-toggle="collapse">
-            <button
-                class="btn btn-default watched-btn"
-                data-id="<%= movie._id %>"
-            >Have not watched</button>
-            <button
-                class="btn btn-primary watched-btn"
-                data-id="<%= movie._id %>"
-            >Have watched</button>
-            <button
-                class="btn btn-warning watched-btn"
-                data-id="<%= movie._id %>"
-            >Will not watch</button>
-        </div>
-    <% } %>
     </div>
 </div>


### PR DESCRIPTION
Instead of having the title above each movie, which may wrap and cause misalignment between the cover images, this will create an overlay which, on hover, will show the title of the movie and any actions associated with the movie (save -> have seen, have not seen, etc...). This will resolve #7.