### PR TITLE
Made submit script include a db dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ documentation/*.aux
 documentation/*.log
 documentation/*.pdf
 
+# mongodump output
+dump/
+
 # archive files
 *.tar.gz
 *.zip

--- a/submit.sh
+++ b/submit.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 ################################################################################
 # CS 546 Final Project submit.sh
-# 04/28/2016
+# 05/06/2016
 # "We pledge our honor that we have abided by the Stevens Honor System."
 ################################################################################
 
@@ -11,9 +11,12 @@ ASSIGNMENT='cs546-final-project'
 make -C documentation all
 make -C documentation clean
 
+# include a database dump
+mongodump --db ghetto_imdb
+
 # make tar.gz archive for easy submission
-tar -cvzf $ASSIGNMENT.tar.gz ./* --exclude='./node_modules' --exclude='*.zip'
+#tar -cvzf $ASSIGNMENT.tar.gz ./* --exclude='./node_modules' --exclude='*.zip'
 
 # or zip if you prefer
-#zip -r $AUTHOR\_$ASSIGNMENT.zip ./* -x './node_modules/*' '*.tar.gz'
+zip -r $ASSIGNMENT.zip ./* -x './node_modules/*' '*.tar.gz'
 


### PR DESCRIPTION
The submit script now includes a database dump using `mongodump` and I switched
it to make a zip instead of a tar. Also updated the gitignore to ignore the dump
directory created by mongodump.